### PR TITLE
Fixup git-rinse script

### DIFF
--- a/scripts/git-rinse
+++ b/scripts/git-rinse
@@ -26,9 +26,9 @@ delete_branch() {
 }
 
 main() {
-  readonly branches=$(git branch | grep -v master)
+  branches=$(git branch | grep -v master)
 
-  git co master && git pull
+  git co master
   for b in $branches; do
     delete_branch "$b"
   done


### PR DESCRIPTION
- [x] `branches` were marked as readonly; unmark them
- [x] don't pull from master