### PR TITLE
Update git-rinse script

### DIFF
--- a/scripts/git-rinse
+++ b/scripts/git-rinse
@@ -2,14 +2,14 @@
 set -eu
 
 version() {
-  echo "git-rinse v0.1.0"
+  echo "git-rinse v0.2.0"
   echo
 }
 
 usage() {
   echo "usage: git rinse <branch>"
   echo
-  echo "Delete a git branch locally and remotely"
+  echo "Delete a git branch locally"
 }
 
 current_branch() {
@@ -28,7 +28,6 @@ delete_branch() {
 main() {
   branches=$(git branch | grep -v master)
 
-  git co master
   for b in $branches; do
     delete_branch "$b"
   done


### PR DESCRIPTION
This removes `git co master` from the `git-rinse` script as well as updating the usage text to accurately reflect this only deletes local branches. This does mean that you may nuke the branch you are sitting on, however, which to git is fine so long as you are aware. It may be worth doing a patch update here that clarifies that if it's the branch you are sitting on and WARNS you, maybe even taking a `-f` (force) flag.